### PR TITLE
Remove backend as a module attribute, and make it instance attribute instead

### DIFF
--- a/openpmd_viewer/__init__.py
+++ b/openpmd_viewer/__init__.py
@@ -7,9 +7,9 @@ See the class OpenPMDTimeSeries to open a set of openPMD files
 """
 # Make the OpenPMDTimeSeries object accessible from outside the package
 from .openpmd_timeseries import OpenPMDTimeSeries, FieldMetaInformation, \
-    ParticleTracker, backend
+    ParticleTracker
 
 # Define the version number
 from .__version__ import __version__
 __all__ = ['OpenPMDTimeSeries', 'FieldMetaInformation',
-           'ParticleTracker', 'backend', '__version__']
+           'ParticleTracker', '__version__']

--- a/openpmd_viewer/openpmd_timeseries/__init__.py
+++ b/openpmd_viewer/openpmd_timeseries/__init__.py
@@ -1,6 +1,4 @@
 # Make the OpenPMDTimeSeries accessible from outside the file main
 from .main import OpenPMDTimeSeries, ParticleTracker
-from .data_reader import backend
 from .field_metainfo import FieldMetaInformation
-__all__ = ['OpenPMDTimeSeries', 'FieldMetaInformation',
-            'ParticleTracker', 'backend']
+__all__ = ['OpenPMDTimeSeries', 'FieldMetaInformation', 'ParticleTracker']

--- a/openpmd_viewer/openpmd_timeseries/data_reader/__init__.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/__init__.py
@@ -1,2 +1,2 @@
-from .data_reader import DataReader, backend
-__all__ = ['DataReader', 'backend']
+from .data_reader import DataReader, available_backends
+__all__ = ['DataReader', 'available_backends']

--- a/openpmd_viewer/openpmd_timeseries/data_reader/data_reader.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/data_reader.py
@@ -8,32 +8,29 @@ Copyright 2020, openPMD-viewer contributors
 Authors: Remi Lehe
 License: 3-Clause-BSD-LBNL
 """
+import numpy as np
+import os
+import re
 
-backend_avail = []
+available_backends = []
 
 try:
     import openpmd_api as io
     from . import io_reader
-    backend_avail.append('openpmd-api')
+    available_backends.append('openpmd-api')
 except ImportError:
     pass
 
 try:
     from . import h5py_reader
-    backend_avail.append('h5py')
+    available_backends.append('h5py')
 except ImportError:
     pass
 
-if len(backend_avail)>0:
-    backend = backend_avail[0]
-else:
-    print('No backends are found')
-    raise ImportError
-
-import numpy as np
-import os
-import re
-
+if len(available_backends) == 0:
+    raise ImportError('No openPMD backend found.\n'
+        'Please install either `h5py` or `openpmd-api`:\n'
+        'e.g. with `pip install h5py` or `pip install openpmd-api`')
 
 class DataReader( object ):
     """
@@ -49,11 +46,7 @@ class DataReader( object ):
         """
         Initialize the DataReader class.
         """
-
-        if backend_set is not None:
-            self.backend = backend_set
-        else:
-            self.backend = backend
+        self.backend = backend_set
 
         # Point to the correct reader module
         if self.backend == 'h5py':

--- a/openpmd_viewer/openpmd_timeseries/data_reader/data_reader.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/data_reader.py
@@ -42,11 +42,11 @@ class DataReader( object ):
     available on the current environment.
     """
 
-    def __init__(self, backend_set):
+    def __init__(self, backend):
         """
         Initialize the DataReader class.
         """
-        self.backend = backend_set
+        self.backend = backend
 
         # Point to the correct reader module
         if self.backend == 'h5py':

--- a/openpmd_viewer/openpmd_timeseries/main.py
+++ b/openpmd_viewer/openpmd_timeseries/main.py
@@ -14,7 +14,7 @@ from .utilities import apply_selection, fit_bins_to_grid, try_array, \
                         sanitize_slicing, combine_cylindrical_components
 from .plotter import Plotter
 from .particle_tracker import ParticleTracker
-from .data_reader import DataReader
+from .data_reader import DataReader, available_backends
 from .interactive import InteractiveViewer
 
 
@@ -57,6 +57,15 @@ class OpenPMDTimeSeries(InteractiveViewer):
             or `h5py`. If not provided will use `openpmd-api` if available
             and `h5py` otherwise.
         """
+        # Check backend
+        if backend is None:
+            backend = available_backends[0] #Pick openpmd-api first if available
+        elif backend not in available_backends:
+            raise RuntimeError("Invalid backend requested: {0}\n"
+                    "The available backends are: {1}"
+                    .format(backend, available_backends) )
+        self.backend = backend
+
         # Initialize data reader
         self.data_reader = DataReader(backend)
 


### PR DESCRIPTION
This finalizes some modifications related to backends:
- Clearer error messages when some backends are not available.
- The backend is now an attribute of `OpenPMDTimeSeries` (e.g. accessible via `ts.backend`) instead of being an attribute of the `openpmd_viewer` module (which was accessible via `openpmd_viewer.backend`).